### PR TITLE
fix: Move to repo-based generation test

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,33 @@
+name: Catalog Generation
+
+on:
+  workflow_run:
+    workflows:
+      - Preflight Test
+    types:
+      - completed
+
+jobs:
+  build:
+    name: Image build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install OPM
+        run: |
+          make opm
+
+      - name: Login to registry.redhat.io
+        uses: docker/login-action@v3
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_USERNAME }}
+          password: ${{ secrets.RH_TOKEN }}
+
+      - name: Generate catalog
+        run: |
+          export PATH=$PATH:${PWD}/bin
+          ./build/generate-catalog.sh
+          git diff --exit-code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,19 +20,6 @@ jobs:
         run: |
           make opm
 
-      - name: Login to registry.redhat.io
-        uses: docker/login-action@v3
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_USERNAME }}
-          password: ${{ secrets.RH_TOKEN }}
-
-      - name: Generate catalog
-        run: |
-          export PATH=$PATH:${PWD}/bin
-          ./build/generate-catalog.sh
-          git diff --exit-code
-
       - name: Validate catalog
         run: |
           make validate-catalog


### PR DESCRIPTION
Otherwise, forks won't have access to submit PRs since the new workflow has secrets.